### PR TITLE
 fix: remove doc type filtering from the mapper

### DIFF
--- a/litigation_data_mapper/parsers/document.py
+++ b/litigation_data_mapper/parsers/document.py
@@ -1,11 +1,8 @@
-import os
 from typing import Any, Optional, Union
 
 import click
 
 from litigation_data_mapper.datatypes import Failure, LitigationContext
-
-SUPPORTED_FILE_EXTENSIONS = [".pdf", ".html"]
 
 
 def get_document_headline(
@@ -157,18 +154,6 @@ def process_family_documents(
                 context.failures.append(
                     Failure(
                         id=document_id, type="document", reason="Missing a source url"
-                    )
-                )
-                context.skipped_documents.append(document_id)
-                continue
-
-            _, ext = os.path.splitext(document_source_url)
-            if ext.lower() not in SUPPORTED_FILE_EXTENSIONS:
-                context.failures.append(
-                    Failure(
-                        id=document_id,
-                        type="document",
-                        reason=f"Document has invalid file ext [{ext}]",
                     )
                 )
                 context.skipped_documents.append(document_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "litigation-data-mapper"
-version = "0.6.3"
+version = "0.6.4"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 license = "Apache 2.0"

--- a/tests/unit_tests/document/test_map_document.py
+++ b/tests/unit_tests/document/test_map_document.py
@@ -169,28 +169,6 @@ def test_skips_mapping_document_if_it_does_not_have_a_file_id(
     )
 
 
-def test_skips_mapping_document_if_source_url_does_not_have_supported_file_extension(
-    mock_global_case, mock_pdf_urls
-):
-    case_id = 2
-    mock_file_id = 123
-    mock_pdf_urls[mock_file_id] = "https://energy/case-document.csv"
-    mock_global_case["acf"]["ccl_nonus_case_documents"][0][
-        "ccl_nonus_file"
-    ] = mock_file_id
-    mapped_documents = process_family_documents(
-        mock_global_case, case_id, mock_pdf_urls, mock_context
-    )
-
-    assert mock_context.failures[-1] == Failure(
-        id=123, type="document", reason="Document has invalid file ext [.csv]"
-    )
-    assert not isinstance(mapped_documents, Failure)
-    assert len(mapped_documents) != len(
-        mock_global_case.get("acf", {}).get("ccl_nonus_case_documents")
-    )
-
-
 def test_generates_global_case_document_title(mock_global_case):
     case_document = mock_global_case.get("acf", {}).get("ccl_nonus_case_documents")[0]
     case_type = "non_us_case"


### PR DESCRIPTION
 - basically the pipeline takes care of these and can handle all extension types and have a process checking documents after they have been ingested. so per data science request we are removing this

# What's changed?

- Provide a general summary of your changes

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
