### PR TITLE
Configure uv to install main dependencies as default

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,7 +95,7 @@ jobs:
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
 
       - name: Run Tests
-        run: python -m pytest -vvv
+        run: uv run pytest -vvv
 
   git:
     if: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,7 +95,7 @@ jobs:
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
 
       - name: Run Tests
-        run: .venv/bin/python -m pytest -vvv
+        run: python -m pytest -vvv
 
   git:
     if: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -171,4 +171,4 @@ jobs:
           DOCKER_TAG: latest
           PREFECT_API_KEY: ${{ secrets.PREFECT_API_KEY }}
           PREFECT_API_URL: ${{ secrets.PREFECT_API_URL }}
-        run: python create_deployment.py
+        run: uv run python create_deployment.py

--- a/litigation_data_mapper/cli.py
+++ b/litigation_data_mapper/cli.py
@@ -78,6 +78,11 @@ def entrypoint(
     click.echo("🚀 Dumping litigation data to output file")
     dump_output(mapped_data, output_file, debug)
     click.echo("✅ Finished dumping mapped litigation data.")
+    click.echo("📝 Mapped:")
+    click.echo(f"   {len(mapped_data['collections'])} collections")
+    click.echo(f"   {len(mapped_data['families'])} families")
+    click.echo(f"   {len(mapped_data['documents'])} documents")
+    click.echo(f"   {len(mapped_data['events'])} events")
 
 
 def wrangle_data(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]
-default-groups = []
+default-groups = ["dev"]
 
 [tool.pyright]
 exclude = ["**/__pycache__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]
-default-groups = ["dev"]
+default-groups = []
 
 [tool.pyright]
 exclude = ["**/__pycache__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "boto3>=1.35.87",
 ]
 name = "litigation-data-mapper"
-version = "1.3.2"
+version = "1.3.3"
 description = ""
 
 [project.scripts]
@@ -25,7 +25,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]
-default-groups = []
+default-groups = ["default"]
 
 [tool.pyright]
 exclude = ["**/__pycache__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,6 @@ dev = ["pytest<9.0.0,>=8.3.2", "cookiecutter<3.0.0,>=2.6.0"]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.uv]
-default-groups = ["default"]
-
 [tool.pyright]
 exclude = ["**/__pycache__"]
 pythonVersion = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dev = ["pytest<9.0.0,>=8.3.2", "cookiecutter<3.0.0,>=2.6.0"]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.uv]
+default-groups = []
+
 [tool.pyright]
 exclude = ["**/__pycache__"]
 pythonVersion = "3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "litigation-data-mapper"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "litigation-data-mapper"
-version = "1.3.2"
+version = "1.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
# What's changed?

- remove venv when running tests in the CI as this was unnecessary
- use uv to run tests and create Prefect deployment in CICD
- add extra logging after the data mapping is finished

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
