### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ FROM prefecthq/prefect:2.20.7-python3.10
 
 # Install uv (fast Python dependency manager)
 RUN pip install --no-cache-dir uv==0.6.16
+# This ensures that the dependencies are installed at system python level
+# without having to activate a venv
+ENV UV_PROJECT_ENVIRONMENT="/usr/local/"
 
-# Copy dependency files and install dependencies
+# Copy dependency files
 COPY pyproject.toml uv.lock ./
-RUN uv sync
-
 # Copy your source code
 COPY litigation_data_mapper litigation_data_mapper
-# Install dependencies
-RUN uv sync
+
+# Install dependencies using the lockfile without checking if it is up-to-date
+RUN uv sync --frozen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "boto3>=1.35.87",
 ]
 name = "litigation-data-mapper"
-version = "1.3.3"
+version = "1.3.4"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- set UV_PROJECT_ENVIRONMENT  so that dependencies are installed at system python level without having to activate a virtual environment which is unnecessary in a docker container
- add --frozen flag to the uv sync command so that the lock file is not regenerated by default (this ensures consistency with other environments)
- remove the duplicated uv sync and instead sync at the end which installs the dependencies and the project at the same time

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
