### PR TITLE
feat: update the time delta to be 48 hours instead of 24

### DIFF
--- a/litigation_data_mapper/cli.py
+++ b/litigation_data_mapper/cli.py
@@ -106,7 +106,7 @@ def wrangle_data(
         failures=[],
         debug=debug,
         get_modified_data=get_modified_data,
-        last_import_date=datetime.now() - timedelta(hours=24),
+        last_import_date=datetime.now() - timedelta(hours=48),
         case_bundles={},
         skipped_families=[],
         skipped_documents=[],

--- a/tests/unit_tests/test_wrangle_data.py
+++ b/tests/unit_tests/test_wrangle_data.py
@@ -259,14 +259,14 @@ def test_skips_mapping_litigation_data_outside_of_update_window(mock_litigation_
 
 
 @freeze_time("2025-06-01T00:00:00")
-def test_only_maps_litigation_data_that_was_modified_within_the_last_24_hrs(
+def test_only_maps_litigation_data_that_was_modified_within_the_last_48_hrs(
     mock_litigation_data, expected_mapped_data
 ):
     mock_litigation_data["collections"][0]["modified_gmt"] = "2025-05-31T12:00:00"
     mock_litigation_data["collections"].append(
         {
             "id": 2,
-            "modified_gmt": "2025-05-30T12:00:00",
+            "modified_gmt": "2025-05-29T12:00:00",
             "type": "case_bundle",
             "title": {"rendered": "Test US case bundle title"},
             "acf": {
@@ -283,7 +283,7 @@ def test_only_maps_litigation_data_that_was_modified_within_the_last_24_hrs(
     ] = "2025-05-31T12:00:00"
     mock_litigation_data["families"]["global_cases"][0][
         "modified_gmt"
-    ] = "2025-05-30T12:00:00"
+    ] = "2025-05-29T12:00:00"
 
     assert wrangle_data(mock_litigation_data, debug=True, get_modified_data=True) == {
         "collections": expected_mapped_data["collections"],


### PR DESCRIPTION
# What's changed?

- Set time delta to 48 hours

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
