### PR TITLE
Feature/app 556 add error notification for prefect failures

### DIFF
--- a/litigation_data_mapper/utils.py
+++ b/litigation_data_mapper/utils.py
@@ -11,15 +11,13 @@ class SlackNotify:
     # Message templates
     FLOW_RUN_URL = "{prefect_base_url}/flow-runs/flow-run/{flow_run.id}"
     BASE_MESSAGE = (
-        "Flow run {flow.name}/{flow_run.name} observed in "
-        "state `{flow_run.state.name}` at {flow_run.state.timestamp}. "
-        "For environment: {environment}. "
-        "Flow run URL: {ui_url}. "
-        "State message: {state.message}"
+        "💥 Flow run <{ui_url}|{flow.name}/{flow_run.name}> "
+        "state `{flow_run.state.name}` at {flow_run.state.timestamp}.\n"
+        "Error message: {state.message}"
     )
 
     # Block name
-    slack_channel_name = "platform"
+    slack_channel_name = "prod_updates"
 
     @classmethod
     def get_environment(cls) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "boto3>=1.35.87",
 ]
 name = "litigation-data-mapper"
-version = "1.3.7"
+version = "1.3.8"
 description = ""
 
 [project.scripts]

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -19,7 +19,7 @@ async def test_message_sends_notification_in_prod(
 
         # Verify webhook was loaded
         mock_SlackWebhook.load.assert_called_once_with(
-            "slack-webhook-platform-prefect-mvp-prod"
+            "slack-webhook-prod_updates-prefect-mvp-prod"
         )
 
         # Verify notification was sent
@@ -27,12 +27,11 @@ async def test_message_sends_notification_in_prod(
         message = mock_prefect_slack_block.notify.call_args.kwargs.get("body", "")
 
         # Check message contains key information without being too strict about format
+        assert "💥 Flow run" in message
         assert "TestFlow/TestFlowRun" in message
         assert "Completed" in message
-        assert "prod" in message
-        assert "test-flow-run-id" in message
-        assert "message" in message
         assert "http://127.0.0.1:1234" in message
+        assert "Error message: message" in message
 
 
 @pytest.mark.asyncio
@@ -151,8 +150,8 @@ async def test_message_formatting(mock_prefect_slack_webhook, mock_flow, mock_fl
         # Verify exact message format
         expected_url = "http://127.0.0.1:1234/flow-runs/flow-run/test-flow-run-id"
         expected_message = (
-            f"Flow run TestFlow/TestFlowRun observed in state `Completed` "
-            f"at 2025-01-28T12:00:00+00:00. For environment: prod. "
-            f"Flow run URL: {expected_url}. State message: message"
+            f"💥 Flow run <{expected_url}|TestFlow/TestFlowRun> "
+            f"state `Completed` at 2025-01-28T12:00:00+00:00.\n"
+            f"Error message: message"
         )
         assert message == expected_message


### PR DESCRIPTION
# What's changed?

- Change Slack notification format and push to #prod_updates instead of #platform

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
