### PR TITLE
Feature/app 556 add error notification for prefect failures

### DIFF
--- a/litigation_data_mapper/utils.py
+++ b/litigation_data_mapper/utils.py
@@ -17,7 +17,7 @@ class SlackNotify:
     )
 
     # Block name
-    slack_channel_name = "prod_updates"
+    slack_channel_name = "prod-updates"
 
     @classmethod
     def get_environment(cls) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "boto3>=1.35.87",
 ]
 name = "litigation-data-mapper"
-version = "1.3.8"
+version = "1.3.9"
 description = ""
 
 [project.scripts]

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -19,7 +19,7 @@ async def test_message_sends_notification_in_prod(
 
         # Verify webhook was loaded
         mock_SlackWebhook.load.assert_called_once_with(
-            "slack-webhook-prod_updates-prefect-mvp-prod"
+            "slack-webhook-prod-updates-prefect-mvp-prod"
         )
 
         # Verify notification was sent


### PR DESCRIPTION
# What's changed?

- fix incorrect slack channel name

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
