### PR TITLE
feat: map new event type

### DIFF
--- a/litigation_data_mapper/enums/events.py
+++ b/litigation_data_mapper/enums/events.py
@@ -95,3 +95,4 @@ class EventType(Enum):
     TENTATIVE_RULING = "Tentative Ruling"
     TRANSCRIPT = "Transcript"
     VERDICT = "Verdict"
+    SUBSTITUTION_OF_PARTIES = "Substitution Of Parties"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "boto3>=1.35.87",
 ]
 name = "litigation-data-mapper"
-version = "1.3.9"
+version = "1.3.10"
 description = ""
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "boto3>=1.35.87",
 ]
 name = "litigation-data-mapper"
-version = "1.3.5"
+version = "1.3.6"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- Map new event type. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
