### PR TITLE
Final test of the failure notification

### DIFF
--- a/litigation_data_mapper/flows.py
+++ b/litigation_data_mapper/flows.py
@@ -27,6 +27,7 @@ def automatic_updates(debug=True):
     maps it to a json file and sends that file to the admin service API to trigger a bulk import/update.
     """
     logger.info("🚀 Starting automatic litigation update flow.")
+    raise Exception("Testing failure notifications")
 
     try:
         output_file = os.path.join(os.getcwd(), "output.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
   "boto3>=1.35.87",
 ]
 name = "litigation-data-mapper"
-version = "1.3.11"
+version = "1.3.12"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- add exception throwing again for a final test of failure notifications

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
