### PR TITLE
Feature/app 475 improve docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,3 @@ RUN mkdir -p /opt/prefect && \
 
 # Switch to non-root user
 USER prefect_user
-
-CMD ["sleep", "10000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,13 @@ RUN UV_VERSION=$(grep "uv>=" pyproject.toml | cut -d'=' -f2 | tr -d '"' | tr -d 
 RUN uv sync --frozen
 
 # Set up permissions for prefect_user
-RUN chown -R prefect_user:prefect_user /home/prefect_user && \
+RUN mkdir -p /opt/prefect && \
+    chown -R prefect_user:prefect_user /opt/prefect && \
+    chmod -R 755 /opt/prefect && \
+    chown -R prefect_user:prefect_user /home/prefect_user && \
     chown -R prefect_user:prefect_user /usr/local/lib/python3.10/site-packages
 
 # Switch to non-root user
 USER prefect_user
+
+CMD ["sleep", "10000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "uv>=0.7.6",
 ]
 name = "litigation-data-mapper"
-version = "1.3.14"
+version = "1.3.15"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- add missing permissions to the Dockerfile so that Prefect can write the output.json, litigation_raw_data_output.json and error_log.txt

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
