### PR TITLE
Feature/app 459 collate list of sabin casesdocuments with missing

### DIFF
--- a/litigation_data_mapper/enums/events.py
+++ b/litigation_data_mapper/enums/events.py
@@ -56,6 +56,105 @@ class EventType(Enum):
     NOTICE_OF_RULING = "Notice Of Ruling"
     NOTICE_OF_VOLUNTARY_DISMISSAL = "Notice Of Voluntary Dismissal"
     NOTIFICATION = "Notification"
+    OBJECTIONS = "Objections"
+    OPINION = "Opinion"
+    OPINION_AND_ORDER = "Opinion And Order"
+    OPPOSITION = "Opposition"
+    ORDER = "Order"
+    ORDER_DENYING_PETITION_FOR_REVIEW = "Order Denying Petition For Review"
+    ORDER_LIST = "Order List"
+    ORDER_TO_SHOW_CAUSE = "Order To Show Cause"
+    PETITION = "Petition"
+    PETITION_FOR_RECONSIDERATION = "Petition For Reconsideration"
+    PETITION_FOR_REHEARING = "Petition For Rehearing"
+    PETITION_FOR_REVIEW = "Petition For Review"
+    PETITION_FOR_RULEMAKING = "Petition For Rulemaking"
+    PETITION_FOR_WRIT_OF_CERTIORARI = "Petition For Writ Of Certiorari"
+    PETITION_FOR_WRIT_OF_MANDATE = "Petition For Writ Of Mandate"
+    PLEA = "Plea"
+    POINTS_OF_CLAIM = "Points Of Claim"
+    PRESS_RELEASE = "Press Release"
+    REPLY = "Reply"
+    REQUEST = "Request"
+    REQUEST_FOR_ADMINISTRATIVE_STAY = "Request For Administrative Stay"
+    REQUEST_FOR_REHEARING = "Request For Rehearing"
+    REPORT_AND_RECOMMENDATION = "Report And Recommendation"
+    RESPONSE = "Response"
+    RESPONSE_TO_PETITION_FOR_RULEMAKING = "Response To Petition For Rulemaking"
+    RULING = "Ruling"
+    SETTLEMENT = "Settlement"
+    SETTLEMENT_AGREEMENT = "Settlement Agreement"
+    STATEMENT = "Statement"
+    STATEMENT_OF_ISSUES = "Statement Of Issues"
+    STATEMENT_OF_REPLY = "Statement Of Reply"
+    STATUS_REPORT = "Status Report"
+    STIPULATION = "Stipulation"
+    SUBPOENA = "Subpoena"
+    SUR_REPLY = "Sur-Reply"
+    SUMMONS = "Summons"
+    SUPPLEMENT = "Supplement"
+    TENTATIVE_RULING = "Tentative Ruling"
+    TRANSCRIPT = "Transcript"
+    VERDICT = "Verdict"
+    SUBSTITUTION_OF_PARTIES = "Substitution Of Parties"
+    OTHER = "Other"
+
+
+class DocType(Enum):
+    ADMINISTRATIVE_ORDER = "Administrative Order"
+    AFFIDAVIT = "Affidavit"
+    AFFIRMATION = "Affirmation"
+    AFFIXED = "Affixed"
+    AMICUS_BRIEF = "Amicus Brief"
+    AMICUS_MOTION = "Amicus Motion"
+    ANSWER = "Answer"
+    APPEAL = "Appeal"
+    APPENDIX = "Appendix"
+    APPLICATION = "Application"
+    APPLICATION_FOR_ADMINISTRATIVE_STAY = "Application For Administrative Stay"
+    ASSURANCE_OF_DISCONTINUANCE = "Assurance Of Discontinuance"
+    BILL_OF_COMPLAINT = "Bill Of Complaint"
+    BRIEF = "Brief"
+    COMPLAINT = "Complaint"
+    CONCILIATION_AGREEMENT = "Conciliation Agreement"
+    CONSENT_DECREE = "Consent Decree"
+    CONSENT_MOTION = "Consent Motion"
+    CONSENT_ORDER = "Consent Order"
+    DECLARATION = "Declaration"
+    DECISION = "Decision"
+    EXHIBIT = "Exhibit"
+    EXPERT_REPORT = "Expert Report"
+    FEDERAL_REGISTER_NOTICE = "Federal Register Notice"
+    FILING_YEAR_FOR_ACTION = "Filing Year For Action"
+    FINAL_DECISION = "Final Decision"
+    FINAL_DETERMINATION = "Final Determination"
+    FINDINGS_AND_RECOMMENDATIONS = "Findings And Recommendations"
+    FINDINGS_OF_FACT_AND_CONCLUSIONS_OF_LAW = "Findings Of Fact And Conclusions Of Law"
+    JOINT_PROPOSED_REMEDY = "Joint Proposed Remedy"
+    JOINDER = "Joinder"
+    JUDGMENT = "Judgment"
+    LETTER = "Letter"
+    MEMORANDUM = "Memorandum"
+    MEMORANDUM_AND_ORDER = "Memorandum And Order"
+    MEMORANDUM_DECISION = "Memorandum Decision"
+    MEMORANDUM_OF_DECISION = "Memorandum Of Decision"
+    MEMORANDUM_OF_LAW = "Memorandum Of Law"
+    MEMORANDUM_OPINION = "Memorandum Opinion"
+    MEMORANDUM_OPINION_AND_ORDER = "Memorandum Opinion And Order"
+    MINUTE_ORDER = "Minute Order"
+    MINUTE_PROCEEDINGS = "Minute Proceedings"
+    MOTION = "Motion"
+    MOTION_FOR_SUMMARY_JUDGMENT = "Motion For Summary Judgment"
+    MOTION_TO_DISMISS = "Motion To Dismiss"
+    MOTION_TO_INTERVENE = "Motion To Intervene"
+    NOTICE = "Notice"
+    NOTICE_OF_APPEAL = "Notice Of Appeal"
+    NOTICE_OF_INTENT = "Notice Of Intent"
+    NOTICE_OF_INTENT_TO_SUE = "Notice Of Intent To Sue"
+    NOTICE_OF_REMOVAL = "Notice Of Removal"
+    NOTICE_OF_RULING = "Notice Of Ruling"
+    NOTICE_OF_VOLUNTARY_DISMISSAL = "Notice Of Voluntary Dismissal"
+    NOTIFICATION = "Notification"
     OBJECTION = "Objection"
     OPINION = "Opinion"
     OPINION_AND_ORDER = "Opinion And Order"
@@ -95,4 +194,105 @@ class EventType(Enum):
     TENTATIVE_RULING = "Tentative Ruling"
     TRANSCRIPT = "Transcript"
     VERDICT = "Verdict"
-    SUBSTITUTION_OF_PARTIES = "Substitution Of Parties"
+    NA = "Na"
+
+
+DOC_TYPE_TO_EVENT_TYPE = {
+    DocType.ADMINISTRATIVE_ORDER: EventType.ORDER,
+    # DocType.AFFIDAVIT: "Affidavit/Declaration",
+    # DocType.AFFIRMATION: "Affidavit/Declaration",
+    # DocType.AFFIXED: None,
+    # DocType.AMICUS_BRIEF: "Amicus Motion/Brief",
+    # DocType.AMICUS_MOTION: "Amicus Motion/Brief",
+    DocType.ANSWER: EventType.ANSWER,
+    DocType.APPEAL: EventType.APPEAL,
+    # DocType.APPENDIX: "Appendix/Exhibit/Supplement",
+    DocType.APPLICATION: EventType.APPLICATION,
+    DocType.APPLICATION_FOR_ADMINISTRATIVE_STAY: EventType.APPLICATION,
+    # DocType.ASSURANCE_OF_DISCONTINUANCE: None,  No longer used
+    DocType.BILL_OF_COMPLAINT: EventType.MOTION,
+    DocType.BRIEF: EventType.BRIEF,
+    DocType.COMPLAINT: EventType.COMPLAINT,
+    DocType.CONCILIATION_AGREEMENT: EventType.SETTLEMENT_AGREEMENT,
+    # DocType.CONSENT_DECREE: "Consent Decree/Order",
+    # DocType.CONSENT_MOTION: "Consent Decree/Order",
+    # DocType.CONSENT_ORDER: "Consent Decree/Order",
+    # DocType.DECLARATION: "Affidavit/Declaration",
+    DocType.DECISION: EventType.DECISION,
+    # DocType.EXHIBIT: "Appendix/Exhibit/Supplement",
+    DocType.EXPERT_REPORT: EventType.EXPERT_REPORT,
+    DocType.FEDERAL_REGISTER_NOTICE: EventType.NOTICE,
+    DocType.FILING_YEAR_FOR_ACTION: EventType.FILING_YEAR_FOR_ACTION,
+    DocType.FINAL_DECISION: EventType.DECISION,
+    # DocType.FINAL_DETERMINATION: None,
+    DocType.FINDINGS_AND_RECOMMENDATIONS: EventType.REPORT_AND_RECOMMENDATION,
+    DocType.FINDINGS_OF_FACT_AND_CONCLUSIONS_OF_LAW: EventType.DECISION,
+    DocType.JOINT_PROPOSED_REMEDY: EventType.SETTLEMENT,
+    DocType.JOINDER: EventType.MOTION,
+    DocType.JUDGMENT: EventType.DECISION,
+    DocType.LETTER: EventType.LETTER,
+    # DocType.MEMORANDUM: None,
+    DocType.MEMORANDUM_AND_ORDER: EventType.DECISION,
+    DocType.MEMORANDUM_DECISION: EventType.DECISION,
+    DocType.MEMORANDUM_OF_DECISION: EventType.DECISION,
+    DocType.MEMORANDUM_OF_LAW: EventType.BRIEF,
+    DocType.MEMORANDUM_OPINION: EventType.DECISION,
+    DocType.MEMORANDUM_OPINION_AND_ORDER: EventType.DECISION,
+    DocType.MINUTE_ORDER: EventType.DECISION,
+    DocType.MINUTE_PROCEEDINGS: EventType.TRANSCRIPT,
+    DocType.MOTION: EventType.MOTION,
+    DocType.MOTION_FOR_SUMMARY_JUDGMENT: EventType.MOTION_FOR_SUMMARY_JUDGMENT,
+    DocType.MOTION_TO_DISMISS: EventType.MOTION_TO_DISMISS,
+    DocType.MOTION_TO_INTERVENE: EventType.MOTION_TO_INTERVENE,
+    DocType.NOTICE: EventType.NOTICE,
+    DocType.NOTICE_OF_APPEAL: EventType.APPEAL,
+    DocType.NOTICE_OF_INTENT: EventType.NOTICE,
+    DocType.NOTICE_OF_INTENT_TO_SUE: EventType.NOTICE_OF_INTENT_TO_SUE,
+    DocType.NOTICE_OF_REMOVAL: EventType.NOTICE_OF_REMOVAL,
+    DocType.NOTICE_OF_RULING: EventType.NOTICE,
+    DocType.NOTICE_OF_VOLUNTARY_DISMISSAL: EventType.NOTICE_OF_VOLUNTARY_DISMISSAL,
+    DocType.NOTIFICATION: EventType.NOTICE,
+    DocType.OBJECTION: EventType.OBJECTIONS,
+    DocType.OPINION: EventType.DECISION,
+    DocType.OPINION_AND_ORDER: EventType.DECISION,
+    DocType.OPPOSITION: EventType.OPPOSITION,
+    DocType.ORDER: EventType.DECISION,
+    DocType.ORDER_DENYING_PETITION_FOR_REVIEW: EventType.DECISION,
+    DocType.ORDER_LIST: EventType.DECISION,
+    DocType.ORDER_TO_SHOW_CAUSE: EventType.DECISION,
+    DocType.PETITION: EventType.PETITION,
+    DocType.PETITION_FOR_RECONSIDERATION: EventType.PETITION,
+    DocType.PETITION_FOR_REHEARING: EventType.PETITION_FOR_REHEARING,
+    DocType.PETITION_FOR_REVIEW: EventType.PETITION,
+    DocType.PETITION_FOR_RULEMAKING: EventType.PETITION,
+    DocType.PETITION_FOR_WRIT_OF_CERTIORARI: EventType.PETITION_FOR_WRIT_OF_CERTIORARI,
+    DocType.PETITION_FOR_WRIT_OF_MANDATE: EventType.PETITION,
+    DocType.PLEA: EventType.PLEA,
+    DocType.POINTS_OF_CLAIM: EventType.COMPLAINT,
+    DocType.PRESS_RELEASE: EventType.PRESS_RELEASE,
+    DocType.REPLY: EventType.REPLY,
+    DocType.REQUEST: EventType.REQUEST,
+    DocType.REQUEST_FOR_ADMINISTRATIVE_STAY: EventType.REQUEST,
+    DocType.REQUEST_FOR_REHEARING: EventType.REQUEST,
+    DocType.REPORT_AND_RECOMMENDATION: EventType.REPORT_AND_RECOMMENDATION,
+    DocType.RESPONSE: EventType.RESPONSE,
+    DocType.RESPONSE_TO_PETITION_FOR_RULEMAKING: EventType.RESPONSE,
+    DocType.RULING: EventType.DECISION,
+    DocType.SETTLEMENT_AGREEMENT: EventType.SETTLEMENT_AGREEMENT,
+    DocType.STATEMENT: EventType.STATEMENT,
+    DocType.STATEMENT_OF_ISSUES: EventType.STATEMENT,
+    DocType.STATEMENT_OF_REPLY: EventType.REPLY,
+    DocType.STATUS_REPORT: EventType.STATUS_REPORT,
+    DocType.STIPULATION: EventType.STIPULATION,
+    DocType.SUBPOENA: EventType.SUBPOENA,
+    DocType.SUR_REPLY: EventType.REPLY,
+    DocType.SUMMONS: EventType.COMPLAINT,
+    # DocType.SUPPLEMENT: "Appendix/Exhibit/Supplement",
+    DocType.TENTATIVE_RULING: EventType.DECISION,
+    DocType.TRANSCRIPT: EventType.TRANSCRIPT,
+    DocType.VERDICT: EventType.VERDICT,
+    DocType.NA: EventType.OTHER,
+}
+
+# TODO : ADD Settlement to Event Type in data migrations
+# TODO: Change objection to objections in data migrations

--- a/litigation_data_mapper/parsers/event.py
+++ b/litigation_data_mapper/parsers/event.py
@@ -4,11 +4,41 @@ from typing import Any
 import click
 
 from litigation_data_mapper.datatypes import Failure, LitigationContext
-from litigation_data_mapper.enums.events import EventType
+from litigation_data_mapper.enums.events import DOC_TYPE_TO_EVENT_TYPE, DocType
 from litigation_data_mapper.parsers.helpers import initialise_counter, write_error_log
 from litigation_data_mapper.parsers.utils import convert_year_to_dmy
 
-EVENT_TYPES = {event.value.lower(): event for event in EventType}
+DOC_TYPES = {doc.value.lower(): doc for doc in DocType}
+
+
+def get_earliest_event_filing_date(documents: dict, documents_key: str) -> str | None:
+    """Returns the earliest filing date from a family case's documents.
+
+    :param dict family: The family case data containing documents.
+    :param str documents_key: The key to access the documents in the family case data.
+    :return str | None: The earliest filing date in 'YYYY-MM-DD' format, or None if no valid dates are found.
+    """
+
+    if not documents:
+        return None
+
+    date_key = (
+        "ccl_filing_date"
+        if documents_key == "ccl_case_documents"
+        else "ccl_nonus_filing_date"
+    )
+
+    dates = [
+        datetime.strptime(doc.get(date_key), "%Y%m%d").strftime("%Y-%m-%d")
+        for doc in documents
+        if doc.get(date_key) is not None
+    ]
+
+    if not dates:
+        return None
+
+    earliest_date = min(dates)
+    return earliest_date
 
 
 def get_key(case_type, case_key: str, nonus_key: str) -> str:
@@ -48,7 +78,14 @@ def get_event_type(doc_type: str) -> str | None:
     :return str | None: The corresponding event type value if found, otherwise None.
     """
 
-    event_type = EVENT_TYPES.get(doc_type.lower())
+    normalised_doc_type = doc_type.strip().lower()
+
+    type = DOC_TYPES.get(normalised_doc_type)
+    if not type:
+        return None
+
+    event_type = DOC_TYPE_TO_EVENT_TYPE.get(type)
+
     return event_type.value if event_type else None
 
 
@@ -58,6 +95,7 @@ def map_event(
     event_import_id: str,
     family_import_id: str,
     case_id: int,
+    fallback_date: str,
 ) -> dict[str, Any] | Failure:
     """Processes an event and maps it to the internal data structure.
 
@@ -67,6 +105,7 @@ def map_event(
     :param str event_import_id: A generated id for the event being mapped.
     :param str family_import_id: A generated id for the family the mapped event is linked to.
     :param int case_id: The unique identifier for the case, used to link events to the correct case.
+    :param str fallback_date: A fallback date to use if the document does not have a filing date.
     :return Optional[dict]: A mapped event in the 'destination' format described in the Litigation Data Mapper Google Sheet, or empty list if no events are found or None.
     """
 
@@ -96,7 +135,10 @@ def map_event(
         document_import_id = f"Sabin.document.{case_id}.{document_id}"
 
     date = doc[get_key(case_type, "ccl_filing_date", "ccl_nonus_filing_date")]
-    parsed_date = datetime.strptime(date, "%Y%m%d").strftime("%Y-%m-%d")
+    if date:
+        parsed_date = datetime.strptime(date, "%Y%m%d").strftime("%Y-%m-%d")
+    else:
+        parsed_date = fallback_date
 
     event_data = {
         "import_id": event_import_id,
@@ -160,14 +202,17 @@ def process_family_events(
             "ccl_nonus_filing_year_for_action",
         )
     ]
-    try:
+    if filing_date:
         filing_year = convert_year_to_dmy(filing_date)
-    except ValueError:
-        return Failure(
-            id=case_id,
-            type="event",
-            reason=f"Event has invalid filing date [{filing_date}]",
-        )
+    else:
+        earliest_date = get_earliest_event_filing_date(documents, documents_key)
+        if not earliest_date:
+            return Failure(
+                id=case_id,
+                type="event",
+                reason=f"Event has invalid filing date [{filing_date}]",
+            )
+        filing_year = earliest_date
 
     family_events.append(
         default_event(
@@ -190,7 +235,12 @@ def process_family_events(
                 f"Sabin.event.{case_id}.n{event_family_counter[family_import_id]:04}"
             )
             event_data = map_event(
-                doc, str(case_type), event_import_id, family_import_id, case_id
+                doc,
+                str(case_type),
+                event_import_id,
+                family_import_id,
+                case_id,
+                filing_year,
             )
             if isinstance(event_data, Failure):
                 context.failures.append(event_data)


### PR DESCRIPTION
# What's changed?

- Update data-mapper to handle the final cases and events with missing information

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
