### PR TITLE
feat: break prefect flow into tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "uv>=0.7.6",
 ]
 name = "litigation-data-mapper"
-version = "1.4.0"
+version = "1.4.1"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- Breaks the flow into two tasks

The intention is to the fork from
```mermaid
flowchart LR
  fetch_litigation_data_task --> trigger_bulk_import
  fetch_litigation_data_task --> save_concepts_to_s3
```

As per the discussion with @climatepolicyradar/software 
![Screenshot 2025-06-24 at 16 59 07](https://github.com/user-attachments/assets/40dacd54-ed5e-4905-b3d7-74c4d9e0536e)


## Proposed version
- [x] Patch
