### PR TITLE
Get concepts from case bundle for US cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,3 @@ cython_debug/
 
 output*.json
 error_log.txt
-litigation_raw_data_output.json

--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -199,7 +199,7 @@ def process_us_case_data(
     # concepts are stored on the case bundle in US cases, so we need to
     # - calculate which bundles are associated with the case
     # - read the concepts from that bundle
-    # - associate those concepts with the case AKA bundle
+    # - associate those concepts with the case AKA family
     bundles = []
     for bundle_id in bundle_ids:
         matched_bundle = next(

--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -202,13 +202,17 @@ def process_us_case_data(
     # - associate those concepts with the case AKA bundle
     bundles = []
     for bundle_id in bundle_ids:
-        matched_bundle = next((x for x in collections if x["id"] == bundle_id), None)
+        matched_bundle = next(
+            (collection for collection in collections if collection["id"] == bundle_id),
+            None,
+        )
         if matched_bundle:
             bundles.append(matched_bundle)
 
     family_concepts = []
     for bundle in bundles:
         family_concepts += get_concepts(bundle, concepts)
+    # /Concepts
 
     family_metadata = process_us_case_metadata(family_data, case_id, family_concepts)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "uv>=0.7.6",
   "boto3-stubs[s3]>=1.38.43",
   "moto[s3]>=5.1.6",
+  "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
 version = "1.4.2"
@@ -19,6 +20,7 @@ description = ""
 
 [project.scripts]
 litigation_data_mapper = "litigation_data_mapper.cli:entrypoint"
+litigation_data_mapper_with_vcr = "litigation_data_mapper.cli:entrypoint_with_vcr"
 
 [dependency-groups]
 dev = [
@@ -29,8 +31,8 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 env = ["AWS_ENV=sandbox"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.4.2"
+version = "1.4.3"
 description = ""
 
 [project.scripts]

--- a/tests/unit_tests/family/test_map_families.py
+++ b/tests/unit_tests/family/test_map_families.py
@@ -85,7 +85,9 @@ def test_skips_mapping_families_if_data_missing_jurisdictions(capsys, mock_conte
         "jurisdictions": [],
     }
 
-    mapped_families = map_families(family_data, context=mock_context, concepts={})
+    mapped_families = map_families(
+        family_data, context=mock_context, concepts={}, collections=[]
+    )
     assert len(mapped_families) == 0
 
     captured = capsys.readouterr()
@@ -104,7 +106,9 @@ def test_skips_mapping_families_if_data_missing_us_cases(capsys, mock_context):
         "jurisdictions": [{"id": 1, "name": "United States", "parent": 0}],
     }
 
-    mapped_families = map_families(family_data, context=mock_context, concepts={})
+    mapped_families = map_families(
+        family_data, context=mock_context, concepts={}, collections=[]
+    )
     assert len(mapped_families) == 0
 
     captured = capsys.readouterr()
@@ -123,7 +127,9 @@ def test_skips_mapping_families_if_data_missing_global_cases(capsys, mock_contex
         "jurisdictions": [{"id": 1, "name": "United States", "parent": 0}],
     }
 
-    mapped_families = map_families(family_data, context=mock_context, concepts={})
+    mapped_families = map_families(
+        family_data, context=mock_context, concepts={}, collections=[]
+    )
     assert len(mapped_families) == 0
 
     captured = capsys.readouterr()
@@ -134,7 +140,9 @@ def test_skips_mapping_families_if_data_missing_global_cases(capsys, mock_contex
 
 
 def test_maps_families(mock_family_data, parsed_family_data, mock_context):
-    family_data = map_families(mock_family_data, context=mock_context, concepts={})
+    family_data = map_families(
+        mock_family_data, context=mock_context, concepts={}, collections=[]
+    )
     assert family_data is not None
     assert len(family_data) == 2
 
@@ -214,7 +222,9 @@ def test_maps_families_handles_no_original_case_name_for_global_cases(mock_conte
         }
     ]
 
-    family_data = map_families(test_family_data, mock_context, concepts={})
+    family_data = map_families(
+        test_family_data, mock_context, concepts={}, collections=[]
+    )
 
     assert family_data == expected_family_data
 
@@ -226,7 +236,9 @@ def test_skips_mapping_families_with_missing_modified_date(mock_context):
         "jurisdictions": [{"id": 1, "name": "United States", "parent": 0}],
     }
 
-    family_data = map_families(test_family_data, context=mock_context, concepts={})
+    family_data = map_families(
+        test_family_data, context=mock_context, concepts={}, collections=[]
+    )
 
     assert not family_data
     assert [1, 2] == mock_context.skipped_families
@@ -256,7 +268,9 @@ def test_ignores_last_updated_date_when_flag_is_false_in_context_and_maps_all_fa
         skipped_families=[],
     )
 
-    family_data = map_families(mock_family_data, context=test_context, concepts={})
+    family_data = map_families(
+        mock_family_data, context=test_context, concepts={}, collections=[]
+    )
 
     assert family_data is not None
     assert len(family_data) == 2

--- a/tests/unit_tests/family/test_map_global_family.py
+++ b/tests/unit_tests/family/test_map_global_family.py
@@ -53,7 +53,9 @@ def test_maps_jurisdictions_to_global_family(mock_family_data: dict, mock_contex
 
     mock_family_data["global_cases"][0]["jurisdiction"] = [2, 3, 4]
 
-    family_data = map_families(mock_family_data, context=mock_context, concepts={})
+    family_data = map_families(
+        mock_family_data, context=mock_context, concepts={}, collections=[]
+    )
     assert family_data is not None
     global_family = family_data[1]
 
@@ -75,7 +77,9 @@ def test_maps_jurisdictions_as_default_international_iso_code_if_case_jurisdicti
         }
 
     mock_family_data["global_cases"][0]["jurisdiction"] = [47]
-    family_data = map_families(mock_family_data, context=mock_context, concepts={})
+    family_data = map_families(
+        mock_family_data, context=mock_context, concepts={}, collections=[]
+    )
     assert family_data is not None
     global_family = family_data[1]
 

--- a/tests/unit_tests/family/test_map_us_family.py
+++ b/tests/unit_tests/family/test_map_us_family.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 from litigation_data_mapper.datatypes import Failure, LitigationContext
+from litigation_data_mapper.extract_concepts import Concept, ConceptType
 from litigation_data_mapper.parsers.family import process_us_case_data
 
 
@@ -212,3 +213,135 @@ def tests_gets_the_latest_document_status(
     )
     assert not isinstance(mapped_family, Failure)
     assert mapped_family["metadata"].get("status") == ["Pending"]
+
+
+def tests_gets_concepts_from_case_bundles(
+    mock_us_case: dict, mock_context: LitigationContext
+):
+    case_id = 1
+
+    # collections = bundles
+    case_bundles_on_case = [1, 2]
+    collections = [
+        # should match
+        {"id": 1, "case_category": [1, 2, 3]},
+        {"id": 2, "case_category": [4, 5, 6], "principal_law": [10, 11, 12]},
+        # shouldn't match
+        {"id": 3, "case_category": [7, 8, 9], "principal_law": [13, 14, 15]},
+    ]
+    mock_us_case["acf"]["ccl_case_bundle"] = case_bundles_on_case
+
+    matching_concepts = {
+        1: Concept(
+            internal_id=1,
+            id="Concept 1",
+            type=ConceptType.LegalCategory,
+            preferred_label="Concept 1",
+        ),
+        2: Concept(
+            internal_id=2,
+            id="Concept 2",
+            type=ConceptType.LegalCategory,
+            preferred_label="Concept 2",
+        ),
+        3: Concept(
+            internal_id=3,
+            id="Concept 3",
+            type=ConceptType.LegalCategory,
+            preferred_label="Concept 3",
+        ),
+        4: Concept(
+            internal_id=4,
+            id="Concept 4",
+            type=ConceptType.LegalCategory,
+            preferred_label="Concept 4",
+        ),
+        5: Concept(
+            internal_id=5,
+            id="Concept 5",
+            type=ConceptType.LegalCategory,
+            preferred_label="Concept 5",
+        ),
+        6: Concept(
+            internal_id=6,
+            id="Concept 6",
+            type=ConceptType.LegalCategory,
+            preferred_label="Concept 6",
+        ),
+        10: Concept(
+            internal_id=10,
+            id="Concept 10",
+            type=ConceptType.Law,
+            preferred_label="Concept 10",
+        ),
+        11: Concept(
+            internal_id=11,
+            id="Concept 11",
+            type=ConceptType.Law,
+            preferred_label="Concept 11",
+        ),
+        12: Concept(
+            internal_id=12,
+            id="Concept 12",
+            type=ConceptType.Law,
+            preferred_label="Concept 12",
+        ),
+    }
+    non_matching_concepts = {
+        7: Concept(
+            internal_id=7,
+            id="Concept 7",
+            type=ConceptType.Law,
+            preferred_label="Concept 7",
+        ),
+        8: Concept(
+            internal_id=8,
+            id="Concept 8",
+            type=ConceptType.Law,
+            preferred_label="Concept 8",
+        ),
+        9: Concept(
+            internal_id=9,
+            id="Concept 9",
+            type=ConceptType.Law,
+            preferred_label="Concept 9",
+        ),
+        13: Concept(
+            internal_id=13,
+            id="Concept 13",
+            type=ConceptType.Law,
+            preferred_label="Concept 13",
+        ),
+        14: Concept(
+            internal_id=14,
+            id="Concept 14",
+            type=ConceptType.Law,
+            preferred_label="Concept 14",
+        ),
+        15: Concept(
+            internal_id=15,
+            id="Concept 15",
+            type=ConceptType.Law,
+            preferred_label="Concept 15",
+        ),
+    }
+
+    mapped_family = process_us_case_data(
+        mock_us_case,
+        case_id,
+        mock_context,
+        concepts={**matching_concepts, **non_matching_concepts},
+        collections=collections,
+    )
+    assert not isinstance(mapped_family, Failure)
+    assert mapped_family["concepts"] == [
+        {
+            "id": c.id,
+            "ids": [],
+            "type": c.type.value if hasattr(c.type, "value") else str(c.type),
+            "preferred_label": c.preferred_label,
+            "relation": c.relation,
+            "subconcept_of_labels": c.subconcept_of_labels,
+        }
+        for c in matching_concepts.values()
+    ]

--- a/tests/unit_tests/family/test_map_us_family.py
+++ b/tests/unit_tests/family/test_map_us_family.py
@@ -41,7 +41,7 @@ def test_maps_us_cases(
 ):
     case_id = mock_us_case.get("id", 1)
     mapped_family = process_us_case_data(
-        mock_us_case, case_id, mock_context, concepts={}
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
     )
 
     assert not isinstance(mapped_family, Failure)
@@ -53,7 +53,7 @@ def test_generates_family_import_id(mock_us_case: dict, mock_context):
     mock_us_case["id"] = case_id
 
     mapped_family = process_us_case_data(
-        mock_us_case, case_id, mock_context, concepts={}
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
     )
     assert not isinstance(mapped_family, Failure)
     assert mapped_family["import_id"] == f"Sabin.family.{case_id}.0"
@@ -69,7 +69,7 @@ def test_maps_collections_to_family(
     mock_context.case_bundles[45] = {"description": "Case relating to case bundle 45"}
 
     mapped_family = process_us_case_data(
-        mock_us_case, case_id, mock_context, concepts={}
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
     )
     assert mapped_family is not None
     assert not isinstance(mapped_family, Failure)
@@ -87,7 +87,7 @@ def test_returns_generic_response_if_no_documents_available_to_calculate_status(
     case_id = 1
 
     mapped_family = process_us_case_data(
-        mock_us_case, case_id, mock_context, concepts={}
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
     )
     assert mapped_family is not None
     assert not isinstance(mapped_family, Failure)
@@ -100,7 +100,7 @@ def test_skips_processing_us_case_data_if_docket_number_is_missing(
     mock_us_case["acf"]["ccl_docket_number"] = ""
     case_id = 1
     mapped_family = process_us_case_data(
-        mock_us_case, case_id, mock_context, concepts={}
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
     )
     assert mapped_family == Failure(
         id=1, type="us_case", reason="Missing the following values: docket_number"
@@ -113,7 +113,9 @@ def test_skips_processing_us_case_data_if_bundle_id_is_missing(
     mock_us_case["acf"]["ccl_case_bundle"] = []
     case_id = 1
 
-    family_data = process_us_case_data(mock_us_case, case_id, mock_context, concepts={})
+    family_data = process_us_case_data(
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
+    )
     assert family_data == Failure(
         id=1, type="us_case", reason="Missing the following values: bundle_ids"
     )
@@ -137,7 +139,9 @@ def test_skips_processing_us_case_data_if_bundle_id_is_not_in_context_bundle_ids
         skipped_families=[],
     )
 
-    family_data = process_us_case_data(mock_us_case, case_id, context, concepts={})
+    family_data = process_us_case_data(
+        mock_us_case, case_id, context, concepts={}, collections=[]
+    )
     assert family_data == Failure(
         id=1, type="us_case", reason="Does not have a valid case bundle"
     )
@@ -148,7 +152,9 @@ def test_skips_processing_us_case_data_if_title_is_missing(
 ):
     mock_us_case["title"]["rendered"] = ""
     case_id = 1
-    family_data = process_us_case_data(mock_us_case, case_id, mock_context, concepts={})
+    family_data = process_us_case_data(
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
+    )
     assert family_data == Failure(
         id=1, type="us_case", reason="Missing the following values: title"
     )
@@ -159,7 +165,9 @@ def test_skips_processing_us_case_data_if_case_has_invalid_state_code(
 ):
     mock_us_case["acf"]["ccl_state"] = "XXX"
     case_id = 1
-    family_data = process_us_case_data(mock_us_case, case_id, mock_context, concepts={})
+    family_data = process_us_case_data(
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
+    )
     assert family_data == Failure(
         id=1, type="us_case", reason="Does not have a valid ccl state code (XXX)"
     )
@@ -177,7 +185,7 @@ def tests_gets_the_latest_document_status_when_there_is_one_document(
     mock_us_case["acf"]["ccl_case_documents"] = documents
     case_id = 1
     mapped_family = process_us_case_data(
-        mock_us_case, case_id, mock_context, concepts={}
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
     )
     assert not isinstance(mapped_family, Failure)
     assert mapped_family["metadata"].get("status") == ["Filed"]
@@ -200,7 +208,7 @@ def tests_gets_the_latest_document_status(
     case_id = 1
 
     mapped_family = process_us_case_data(
-        mock_us_case, case_id, mock_context, concepts={}
+        mock_us_case, case_id, mock_context, concepts={}, collections=[]
     )
     assert not isinstance(mapped_family, Failure)
     assert mapped_family["metadata"].get("status") == ["Pending"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 2
 requires-python = "==3.10.*"
+resolution-markers = [
+    "platform_python_implementation != 'PyPy'",
+    "platform_python_implementation == 'PyPy'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -238,7 +242,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
+    { name = "urllib3", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/ee/b47c0286ada750271897f5cc3e40b4405f1218ff392cd15df993893f0099/botocore-1.38.3.tar.gz", hash = "sha256:790f8f966201781f5fcf486d48b4492e9f734446bbf9d19ef8159d08be854243", size = 13846441, upload-time = "2025-04-25T19:22:27.881Z" }
 wheels = [
@@ -280,7 +285,7 @@ name = "cffi"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
@@ -462,7 +467,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
-    { name = "urllib3" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
+    { name = "urllib3", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
@@ -773,7 +779,7 @@ wheels = [
 
 [[package]]
 name = "litigation-data-mapper"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -783,6 +789,7 @@ dependencies = [
     { name = "moto", extra = ["s3"] },
     { name = "prefect", extra = ["slack"] },
     { name = "pycountry" },
+    { name = "pytest-recording" },
     { name = "requests" },
     { name = "uv" },
 ]
@@ -804,6 +811,7 @@ requires-dist = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.6" },
     { name = "prefect", extras = ["slack"], specifier = ">=3.3.1,<4.0.0" },
     { name = "pycountry", specifier = ">=24.6.1,<25.0.0" },
+    { name = "pytest-recording", specifier = ">=0.13.4" },
     { name = "requests", specifier = ">=2.20.0,<3.0.0" },
     { name = "uv", specifier = ">=0.7.6" },
 ]
@@ -1313,6 +1321,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-recording"
+version = "0.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "vcrpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/9c/f4027c5f1693847b06d11caf4b4f6bb09f22c1581ada4663877ec166b8c6/pytest_recording-0.13.4.tar.gz", hash = "sha256:568d64b2a85992eec4ae0a419c855d5fd96782c5fb016784d86f18053792768c", size = 26576, upload-time = "2025-05-08T10:41:11.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/c2/ce34735972cc42d912173e79f200fe66530225190c06655c5632a9d88f1e/pytest_recording-0.13.4-py3-none-any.whl", hash = "sha256:ad49a434b51b1c4f78e85b1e6b74fdcc2a0a581ca16e52c798c6ace971f7f439", size = 13723, upload-time = "2025-05-08T10:41:09.684Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1450,7 +1471,8 @@ dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "idna" },
-    { name = "urllib3" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
+    { name = "urllib3", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
@@ -1477,7 +1499,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "urllib3" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
+    { name = "urllib3", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/7e/2345ac3299bd62bd7163216702bbc88976c099cfceba5b889f2a457727a1/responses-0.25.7.tar.gz", hash = "sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb", size = 79203, upload-time = "2025-03-11T15:36:16.624Z" }
 wheels = [
@@ -1795,8 +1818,23 @@ wheels = [
 
 [[package]]
 name = "urllib3"
+version = "1.26.20"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_python_implementation == 'PyPy'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
+]
+
+[[package]]
+name = "urllib3"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_python_implementation != 'PyPy'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
@@ -1839,6 +1877,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/ae/9bbb19b9e1c450cf9ecaef06463e40234d98d95bf572fab11b4f19ae5ded/uvicorn-0.34.2.tar.gz", hash = "sha256:0e929828f6186353a80b58ea719861d2629d766293b6d19baf086ba31d4f3328", size = 76815, upload-time = "2025-04-19T06:02:50.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/4b/4cef6ce21a2aaca9d852a6e84ef4f135d99fcd74fa75105e2fc0c8308acd/uvicorn-0.34.2-py3-none-any.whl", hash = "sha256:deb49af569084536d269fe0a6d67e3754f104cf03aba7c11c40f01aadf33c403", size = 62483, upload-time = "2025-04-19T06:02:48.42Z" },
+]
+
+[[package]]
+name = "vcrpy"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation == 'PyPy'" },
+    { name = "urllib3", version = "2.4.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_python_implementation != 'PyPy'" },
+    { name = "wrapt" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/d3/856e06184d4572aada1dd559ddec3bedc46df1f2edc5ab2c91121a2cccdb/vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50", size = 85502, upload-time = "2024-12-31T00:07:57.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/5d/1f15b252890c968d42b348d1e9b0aa12d5bf3e776704178ec37cceccdb63/vcrpy-7.0.0-py2.py3-none-any.whl", hash = "sha256:55791e26c18daa363435054d8b35bd41a4ac441b6676167635d1b37a71dbe124", size = 42321, upload-time = "2024-12-31T00:07:55.277Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What's changed?
- gets concepts (`case_category`, `principle_laws`) from `case_bundle` and apply them to the case
- in the language of the code
  - `case_bundle` => `collection`
  - `case` => `family`
- removes cached version of wordpress and replaces it with a [`vcrpy`](https://vcrpy.readthedocs.io/en/latest/usage.html) version for quicker local testing

## example

[This is a `case_bundle`](https://climatecasechart.com/wp-json/wp/v2/case_bundle/98907), with 
```json
{
  "id": 98907,
  "case_category": [
    401,
    432,
    437,
    421
  ],
  "principal_law": [
    352,
    463,
    2660,
    2661
  ],
}
```

These need to be applied to the case that has
```json
"ccl_case_bundle": [
  98907
]
```

## screenshots

This was run e2e via `litigation-data-mapper -> bulk-import -> admin-service-backend -> navigator-backend/families-api`.

<img width="408" height="921" alt="Screenshot 2025-07-15 at 09 07 49" src="https://github.com/user-attachments/assets/54780c30-d30d-46db-a203-9bb23e19d853" />



## Proposed version

- [x] Patch
