### PR TITLE
Feature/app 1037 principle laws from us missing root us principle law

### DIFF
--- a/litigation_data_mapper/extract_concepts.py
+++ b/litigation_data_mapper/extract_concepts.py
@@ -124,6 +124,25 @@ def map_concept_with_parent_id_to_concept(
         )
 
 
+def add_synthetic_us_principal_law_concept(concepts: dict[int, Concept]):
+    """
+    Adds a synthetic concept for the US principal law to the concepts dictionary.
+    This is necessary because the US principal law is not represented in the WordPress data.
+    """
+    us_principal_law = Concept(
+        internal_id=-1,
+        id="United States of America",
+        type=ConceptType.Law,
+        preferred_label="United States of America",
+        subconcept_of_labels=[],
+        relation="principal_law",
+    )
+
+    concepts[us_principal_law.internal_id] = us_principal_law
+
+    return concepts
+
+
 def extract_concepts() -> dict[int, Concept]:
     concepts_with_parent_id: dict[int, ConceptWithParentId] = {}
     concepts: dict[int, Concept] = {}
@@ -146,7 +165,11 @@ def extract_concepts() -> dict[int, Concept]:
             )
         )
 
-    return concepts
+    concepts_with_synthetic_us_principal_law = add_synthetic_us_principal_law_concept(
+        concepts
+    )
+
+    return concepts_with_synthetic_us_principal_law
 
 
 def fetch_individual_concept(

--- a/litigation_data_mapper/extract_concepts.py
+++ b/litigation_data_mapper/extract_concepts.py
@@ -127,7 +127,9 @@ def map_concept_with_parent_id_to_concept(
         )
 
 
-def add_synthetic_us_principal_law_concept(concepts: dict[int, Concept]):
+def add_synthetic_us_principal_law_concept(
+    concepts: dict[int, Concept],
+) -> dict[int, Concept]:
     """
     Adds a synthetic concept representing the US principal law to the concepts dictionary.
 

--- a/litigation_data_mapper/extract_concepts.py
+++ b/litigation_data_mapper/extract_concepts.py
@@ -8,6 +8,8 @@ from litigation_data_mapper.wordpress import (
     fetch_word_press_data,
 )
 
+US_ROOT_PRINCIPAL_LAW_ID = -1  # Internal ID for the synthetic US principal law concept
+
 wordpress_base_url = "https://climatecasechart.com/wp-json/wp/v2"
 taxonomies = [
     # USA
@@ -126,11 +128,17 @@ def map_concept_with_parent_id_to_concept(
 
 def add_synthetic_us_principal_law_concept(concepts: dict[int, Concept]):
     """
-    Adds a synthetic concept for the US principal law to the concepts dictionary.
-    This is necessary because the US principal law is not represented in the WordPress data.
+    Adds a synthetic concept representing the US principal law to the concepts dictionary.
+
+    This synthetic concept is required because the US principal law is not included
+    in the original WordPress data source but is needed for internal processing.
+
+    :param dict[int, Concept] concepts: A dictionary mapping internal concept IDs to Concept objects.
+
+    :return dict[int, Concept]: The updated concepts dictionary with the synthetic US principal law concept added.
     """
     us_principal_law = Concept(
-        internal_id=-1,
+        internal_id=US_ROOT_PRINCIPAL_LAW_ID,
         id="United States of America",
         type=ConceptType.Law,
         preferred_label="United States of America",

--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -517,10 +517,11 @@ def get_concepts(
     click.echo(f"📝 Mapping concepts for family: {case.get('id')}")
 
     family_concepts = []
-    case_type = case.get("type")
+    is_us_case = case.get("type") in ["case", "case_bundle"]
     us_principal_law = concepts.get(US_ROOT_PRINCIPAL_LAW_ID)
 
     for taxonomy in concept_taxonomies:
+        should_append_root_principal_law = taxonomy == "principal_law" and is_us_case
         concept_ids = case.get(taxonomy, [])
         for concept_id in concept_ids:
             concept = concepts.get(concept_id)
@@ -552,8 +553,8 @@ def get_concepts(
             subconcept_of_labels = concept.subconcept_of_labels.copy()
 
             if (
-                concept.type.value == "law"
-                and case_type in ["case", "case_bundle"]
+                should_append_root_principal_law
+                and concept.type.value == "law"
                 and us_principal_law
             ):
                 subconcept_of_labels.append(us_principal_law.preferred_label)

--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -484,7 +484,13 @@ def add_root_us_principal_law_concept(
     :return list[dict[str, Any]]: The updated list of family concepts.
     """
 
-    us_root_principal_law = concepts[US_ROOT_PRINCIPAL_LAW_ID]
+    us_root_principal_law = concepts.get(US_ROOT_PRINCIPAL_LAW_ID)
+
+    if us_root_principal_law is None:
+        click.echo(
+            f"🛑 US principal law concept with ID {US_ROOT_PRINCIPAL_LAW_ID} not found in concepts."
+        )
+        return family_concepts
 
     has_us_principal_law = any(
         concept.get("type") == "law" and concept.get("relation") == "principal_law"

--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -484,28 +484,22 @@ def add_root_us_principal_law_concept(
     :return list[dict[str, Any]]: The updated list of family concepts.
     """
 
-    us_principal_law = concepts.get(US_ROOT_PRINCIPAL_LAW_ID)
+    us_root_principal_law = concepts[US_ROOT_PRINCIPAL_LAW_ID]
 
-    if us_principal_law is None:
-        click.echo(
-            f"🛑 US principal law concept with ID {US_ROOT_PRINCIPAL_LAW_ID} not found in concepts."
-        )
-        return family_concepts
-
-    has_principal_law = any(
+    has_us_principal_law = any(
         concept.get("type") == "law" and concept.get("relation") == "principal_law"
         for concept in family_concepts
     )
 
-    if has_principal_law:
+    if has_us_principal_law:
         family_concepts.append(
             {
-                "id": us_principal_law.id,
+                "id": us_root_principal_law.id,
                 "ids": [],
-                "type": us_principal_law.type.value,
-                "preferred_label": us_principal_law.preferred_label,
-                "relation": us_principal_law.relation,
-                "subconcept_of_labels": us_principal_law.subconcept_of_labels,
+                "type": us_root_principal_law.type.value,
+                "preferred_label": us_root_principal_law.preferred_label,
+                "relation": us_root_principal_law.relation,
+                "subconcept_of_labels": us_root_principal_law.subconcept_of_labels,
             }
         )
 

--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -470,8 +470,25 @@ def get_concepts(
     click.echo(f"📝 Mapping concepts for family: {case.get('id')}")
 
     family_concepts = []
+    case_type = case.get("type")
+    us_principal_law_concept_id = (
+        -1
+    )  # This is the internal ID for the synthetic US principal law concept
 
     for taxonomy in concept_taxonomies:
+        if taxonomy == "principal_law" and case_type in ["case", "case_bundle"]:
+            us_principal_law = concepts.get(us_principal_law_concept_id)
+            if us_principal_law is not None:
+                family_concepts.append(
+                    {
+                        "id": us_principal_law.id,
+                        "ids": [],
+                        "type": us_principal_law.type.value,
+                        "preferred_label": us_principal_law.preferred_label,
+                        "relation": us_principal_law.relation,
+                        "subconcept_of_labels": us_principal_law.subconcept_of_labels,
+                    },
+                )
         concept_ids = case.get(taxonomy, [])
         for concept_id in concept_ids:
             concept = concepts.get(concept_id)
@@ -500,15 +517,28 @@ def get_concepts(
                     click.echo(f"❌ Error refetching concept {concept_id}: {str(e)}")
                     continue
 
-            family_concepts.append(
-                {
-                    "id": concept.id,
-                    "ids": [],
-                    "type": concept.type.value,
-                    "preferred_label": concept.preferred_label,
-                    "relation": concept.relation,
-                    "subconcept_of_labels": concept.subconcept_of_labels,
-                }
-            )
+            if concept.type == "law" and case_type in ["case", "case_bundle"]:
+                family_concepts.append(
+                    {
+                        "id": concept.id,
+                        "ids": [],
+                        "type": concept.type.value,
+                        "preferred_label": concept.preferred_label,
+                        "relation": concept.relation,
+                        "subconcept_of_labels": concept.subconcept_of_labels
+                        + ["United States of America"],
+                    },
+                )
+            else:
+                family_concepts.append(
+                    {
+                        "id": concept.id,
+                        "ids": [],
+                        "type": concept.type.value,
+                        "preferred_label": concept.preferred_label,
+                        "relation": concept.relation,
+                        "subconcept_of_labels": concept.subconcept_of_labels,
+                    }
+                )
 
     return family_concepts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.4.5"
+version = "1.4.6"
 description = ""
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.4.6"
+version = "1.4.5"
 description = ""
 
 [project.scripts]

--- a/tests/unit_tests/family/test_map_us_family.py
+++ b/tests/unit_tests/family/test_map_us_family.py
@@ -223,6 +223,88 @@ def tests_gets_the_latest_document_status(
 
 
 @patch("litigation_data_mapper.parsers.family.fetch_individual_concept")
+def test_maps_us_root_principal_law_concept(
+    mock_fetch_individual_concept, mock_us_case: dict, mock_context: LitigationContext
+):
+    mock_fetch_individual_concept.return_value = None
+    case_id = 1
+    mock_us_case["principal_law"] = [10, 11]
+    mock_us_case["type"] = "case"
+
+    concepts = {
+        -1: Concept(
+            internal_id=1000,
+            id="United States of America",
+            type=ConceptType.Law,
+            preferred_label="United States of America",
+            subconcept_of_labels=[],
+            relation="principal_law",
+        ),
+        10: Concept(
+            internal_id=10,
+            id="Concept 10",
+            type=ConceptType.Law,
+            preferred_label="Concept 10",
+            relation="principal_law",
+            subconcept_of_labels=[],
+        ),
+        11: Concept(
+            internal_id=11,
+            id="Concept 11",
+            type=ConceptType.Law,
+            preferred_label="Concept 11",
+            relation="principal_law",
+            subconcept_of_labels=[],
+        ),
+        12: Concept(
+            internal_id=12,
+            id="Concept 12",
+            type=ConceptType.LegalCategory,
+            preferred_label="Concept 12",
+            relation=None,
+            subconcept_of_labels=[],
+        ),
+    }
+
+    mapped_family = process_us_case_data(
+        mock_us_case, case_id, mock_context, concepts=concepts, collections=[]
+    )
+    assert not isinstance(mapped_family, Failure)
+
+    assert mapped_family["concepts"] == [
+        {
+            "id": "Concept 10",
+            "ids": [],
+            "type": "law",
+            "preferred_label": "Concept 10",
+            "relation": "principal_law",
+            "subconcept_of_labels": ["United States of America"],
+        },
+        {
+            "id": "Concept 11",
+            "ids": [],
+            "type": "law",
+            "preferred_label": "Concept 11",
+            "relation": "principal_law",
+            "subconcept_of_labels": ["United States of America"],
+        },
+        {
+            "id": "United States of America",
+            "ids": [],
+            "type": "law",
+            "preferred_label": "United States of America",
+            "relation": "principal_law",
+            "subconcept_of_labels": [],
+        },
+    ]
+    assert mapped_family["metadata"].get("concept_preferred_label") == [
+        "principal_law/Concept 10",
+        "principal_law/Concept 11",
+        "principal_law/United States of America",
+    ]
+
+
+@patch("litigation_data_mapper.parsers.family.fetch_individual_concept")
 def tests_gets_concepts_from_case_bundles(
     mock_fetch_individual_concept, mock_us_case: dict, mock_context: LitigationContext
 ):


### PR DESCRIPTION
# What's changed?
Add root us principal law to all us principal law concepts.

There is no root principal law for us cases or case bundles so we have to add it in so that it can be grouped when rendering this data on the frontend.



Manual Testing
<img width="435" height="706" alt="Screenshot 2025-08-19 at 12 15 00" src="https://github.com/user-attachments/assets/b55f72c5-8e71-47be-a1fb-3036962c3758" />

Output
<img width="1019" height="521" alt="Screenshot 2025-08-19 at 13 17 34" src="https://github.com/user-attachments/assets/cd58c252-089c-4c90-ae91-0ed9ce368c45" />
<img width="736" height="684" alt="Screenshot 2025-08-19 at 13 17 42" src="https://github.com/user-attachments/assets/1d36a890-8a0b-4ceb-8940-16eb575fe205" />



## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
