### PR TITLE
fix: use admin.climatecasechart.com as the API domain

### DIFF
--- a/litigation_data_mapper/extract_concepts.py
+++ b/litigation_data_mapper/extract_concepts.py
@@ -12,7 +12,7 @@ from litigation_data_mapper.wordpress import (
 US_ROOT_PRINCIPAL_LAW_ID = -1  # Internal ID for the synthetic US principal law concept
 US_ROOT_JURISDICTION_ID = -2  # Internal ID for the synthetic US jurisdiction concept
 
-wordpress_base_url = "https://climatecasechart.com/wp-json/wp/v2"
+wordpress_base_url = "https://admin.climatecasechart.com/wp-json/wp/v2"
 taxonomies = [
     # USA
     "case_category",

--- a/litigation_data_mapper/fetch_litigation_data.py
+++ b/litigation_data_mapper/fetch_litigation_data.py
@@ -6,11 +6,11 @@ from litigation_data_mapper.extract_concepts import Concept, extract_concepts
 from litigation_data_mapper.wordpress import fetch_word_press_data
 
 ENDPOINTS = {
-    "case_bundles": "https://climatecasechart.com/wp-json/wp/v2/case_bundle",
-    "document_media": "https://climatecasechart.com/wp-json/wp/v2/media",
-    "global_cases": "https://climatecasechart.com/wp-json/wp/v2/non_us_case",
-    "jurisdictions": "https://climatecasechart.com/wp-json/wp/v2/jurisdiction",
-    "us_cases": "https://climatecasechart.com/wp-json/wp/v2/case",
+    "case_bundles": "https://admin.climatecasechart.com/wp-json/wp/v2/case_bundle",
+    "document_media": "https://admin.climatecasechart.com/wp-json/wp/v2/media",
+    "global_cases": "https://admin.climatecasechart.com/wp-json/wp/v2/non_us_case",
+    "jurisdictions": "https://admin.climatecasechart.com/wp-json/wp/v2/jurisdiction",
+    "us_cases": "https://admin.climatecasechart.com/wp-json/wp/v2/case",
 }
 
 

--- a/litigation_data_mapper/wordpress_data.py
+++ b/litigation_data_mapper/wordpress_data.py
@@ -25,7 +25,7 @@ def fetch_and_write_all_wordpress_data():
 
     for endpoint in endpoints:
         data = fetch_word_press_data(
-            f"https://climatecasechart.com/wp-json/wp/v2/{endpoint}"
+            f"https://admin.climatecasechart.com/wp-json/wp/v2/{endpoint}"
         )
 
         with open(f"./build/wordpress/{endpoint}.json", "w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.4.8"
+version = "1.4.9"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- uses admin.climatecasechart.com as the base domain in preperation of redirecting climatecasechart.com => www.climatecasechart.com.


e.g. https://admin.climatecasechart.com/wp-json/wp/v2

as per 
<img width="965" height="339" alt="Screenshot 2025-09-16 at 15 18 33" src="https://github.com/user-attachments/assets/fbd461a8-2c8d-4e21-8f42-b4583860d639" />

- [x] Patch 
