### PR TITLE
Feature/app 1180 geography is wrong on some cases

### DIFF
--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -16,9 +16,15 @@ from litigation_data_mapper.parsers.helpers import (
     parse_document_filing_date,
     return_empty_values,
 )
-from litigation_data_mapper.parsers.utils import last_modified_date, to_us_state_iso
+from litigation_data_mapper.parsers.utils import (
+    convert_iso_alpha2_to_alpha3,
+    last_modified_date,
+    to_us_state_iso,
+)
 
 NO_US_STATE_CODE = "XX"  # Default code for federal cases without a state code
+NO_GEOGRAPHY_CODE = "XAA"
+INTERNATIONAL_CODE = "XAB"
 
 
 def process_global_case_metadata(
@@ -299,29 +305,49 @@ def get_jurisdiction_iso_codes(
     """Retrieve the ISO codes for jurisdictions specified in the family data.
 
     This function checks the jurisdiction IDs in the provided family data against
-    a mapping of jurisdictions to their ISO codes. It returns a list of ISO codes
+    a mapping of jurisdictions to their ISO codes (which contains parent and subdivisions). It returns a list of ISO codes
     for the valid jurisdiction IDs. If no valid jurisdiction IDs are found, it
-    returns a default value.
+    tries to retrieve a fallback iso code from the case country.
 
     :param dict[str, Any] family: A dictionary containing family data, which includes jurisdiction IDs.
     :param dict[str, dict[str, str]] mapped_jurisdictions: A dictionary mapping jurisdiction IDs to their ISO codes.
     :return list[str] : A list of ISO codes for the jurisdictions, or a default value if none are found.
     """
 
-    # No Geography : XAA
-    # International : XAB
-
     if family.get("acf", {}).get("ccl_nonus_case_country") == "XCT":
-        return ["XAB"]
+        return [INTERNATIONAL_CODE]
 
     jurisdiction_ids = family.get("jurisdiction", [])
     iso_codes = []
+    case_assigned_iso_code = family.get("acf", {}).get("ccl_nonus_case_country")
 
     for jurisdiction_id in jurisdiction_ids:
         if jurisdiction_id in mapped_jurisdictions:
             iso_codes.append(mapped_jurisdictions[jurisdiction_id]["iso"])
 
-    return iso_codes if iso_codes else ["XAA"]
+    return iso_codes if iso_codes else get_fallback_iso_code(case_assigned_iso_code)
+
+
+def get_fallback_iso_code(
+    jurisdiction_alpha_2: str | None,
+) -> list[str]:
+    """
+    Converts a given ISO Alpha-2 country code to its corresponding Alpha-3 code.
+
+    This function takes an ISO Alpha-2 country code as input and attempts to convert it
+    to the corresponding ISO Alpha-3 code. If the input code is None or invalid, the function
+    returns No Geography.
+
+    :param str | None jurisdiction_alpha_2: The ISO Alpha-2 country code to be converted.
+    :return list[str]: The corresponding ISO Alpha-3 country code, or No Geography if the input is invalid.
+    """
+
+    if not jurisdiction_alpha_2:
+        return [NO_GEOGRAPHY_CODE]
+
+    fallback_iso_code = convert_iso_alpha2_to_alpha3(jurisdiction_alpha_2)
+
+    return [fallback_iso_code] if fallback_iso_code else [NO_GEOGRAPHY_CODE]
 
 
 def validate_data(
@@ -568,7 +594,7 @@ def add_root_us_jurisdiction_concept(
 def get_concepts(
     case: dict[str, Any], concepts: dict[int, Concept]
 ) -> list[dict[str, Any]]:
-    click.echo(f"📝 Mapping concepts for family: {case.get('id')}")
+    # click.echo(f"📝 Mapping concepts for family: {case.get('id')}")
 
     family_concepts = []
     is_us_case = case.get("type") in ["case", "case_bundle"]
@@ -576,7 +602,6 @@ def get_concepts(
     us_root_jurisdiction = concepts.get(US_ROOT_JURISDICTION_ID)
 
     for taxonomy in concept_taxonomies:
-
         concept_ids = case.get(taxonomy, [])
         for concept_id in concept_ids:
             concept = concepts.get(concept_id)

--- a/litigation_data_mapper/parsers/utils.py
+++ b/litigation_data_mapper/parsers/utils.py
@@ -154,6 +154,15 @@ def get_jurisdiction_iso(jurisdiction: str, parent_id: int) -> str | None:
     return country.alpha_3
 
 
+def convert_iso_alpha2_to_alpha3(iso_alpha2: str) -> str | None:
+    """Converts an ISO alpha-2 code to an ISO alpha-3 code.
+    :param str iso_alpha2: The ISO alpha-2 code to convert.
+    :return str | None : The converted ISO alpha-3 code or none if not found.
+    """
+    country = pycountry.countries.get(alpha_2=iso_alpha2)
+    return country.alpha_3 if country else None
+
+
 def convert_year_to_dmy(year: str) -> str | None:
     """Converts a year to a year-month-day format (YYYY-MM-DD) string.
     :param int year: The year to convert.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.5.4"
+version = "1.5.5"
 description = ""
 
 [project.scripts]

--- a/tests/unit_tests/family/conftest.py
+++ b/tests/unit_tests/family/conftest.py
@@ -165,7 +165,7 @@ def mock_family_data():
                     "ccl_nonus_reporter_info": "1:20-cv-12345",
                     "ccl_nonus_status": "Pending",
                     "ccl_nonus_core_object": "Challenge to the determination that designation of critical habitat for the endangered loch ness would not be prudent.",
-                    "ccl_nonus_case_country": "US",
+                    "ccl_nonus_case_country": "BE",
                     "ccl_nonus_case_documents": [
                         {
                             "ccl_nonus_document_type": "judgment",

--- a/tests/unit_tests/family/test_map_families.py
+++ b/tests/unit_tests/family/test_map_families.py
@@ -329,7 +329,7 @@ def test_fetches_and_maps_any_missing_concepts_when_mapping_families(mock_contex
                         "ccl_nonus_reporter_info": "1:20-cv-12345",
                         "ccl_nonus_status": "Pending",
                         "ccl_nonus_core_object": "Challenge to the determination that designation of critical habitat for the endangered loch ness would not be prudent.",
-                        "ccl_nonus_case_country": "US",
+                        "ccl_nonus_case_country": "AU",
                         "ccl_nonus_case_documents": [
                             {
                                 "ccl_nonus_document_type": "judgment",
@@ -369,7 +369,7 @@ def test_fetches_and_maps_any_missing_concepts_when_mapping_families(mock_contex
                     },
                 ],
                 "geographies": [
-                    "XAA",
+                    "AUS",
                 ],
                 "import_id": "Sabin.family.1.0",
                 "metadata": {

--- a/tests/unit_tests/family/test_map_global_family.py
+++ b/tests/unit_tests/family/test_map_global_family.py
@@ -65,7 +65,7 @@ def test_maps_jurisdictions_to_global_family(mock_family_data: dict, mock_contex
     assert global_family["geographies"] == ["AUS", "CAN", "GBR"]
 
 
-def test_maps_jurisdictions_as_default_no_geography_iso_code_if_case_jurisdiction_not_found(
+def test_maps_global_case_to_fallback_iso_code_if_case_jurisdiction_not_found(
     mock_family_data: dict, mock_context: LitigationContext
 ):
     with patch(
@@ -78,6 +78,32 @@ def test_maps_jurisdictions_as_default_no_geography_iso_code_if_case_jurisdictio
         }
 
     mock_family_data["global_cases"][0]["jurisdiction"] = [47]
+    mock_family_data["global_cases"][0]["acf"]["ccl_nonus_case_country"] = "BE"
+    family_data = map_families(
+        mock_family_data, context=mock_context, concepts={}, collections=[]
+    )
+    assert family_data is not None
+    global_family = family_data[1]
+
+    assert not isinstance(global_family, Failure)
+    assert global_family is not None
+    assert global_family["geographies"] == ["BEL"]
+
+
+def test_maps_global_case_to_no_geography_if_no_jurisdiction_or_fallback_found(
+    mock_family_data: dict, mock_context: LitigationContext
+):
+    with patch(
+        "litigation_data_mapper.parsers.helpers.map_global_jurisdictions"
+    ) as mapped_jurisdictions:
+        mapped_jurisdictions.return_value = {
+            2: {"name": "Canada", "iso": "CAN", "parent": 0},
+            3: {"name": "United Kingdom", "iso": "GBR", "parent": 0},
+            4: {"name": "Australia", "iso": "AUS", "parent": 0},
+        }
+
+    mock_family_data["global_cases"][0]["jurisdiction"] = [47]
+    mock_family_data["global_cases"][0]["acf"]["ccl_nonus_case_country"] = None
     family_data = map_families(
         mock_family_data, context=mock_context, concepts={}, collections=[]
     )


### PR DESCRIPTION
# What's changed?

Add fallback function to get the iso code, where a missing jurisdiction id does not map to an iso code. 

Essentially the endpoint is flakey, and we have found through multiple test runs of this mapper, that sometimes belgium would be mapped to cases and other times it wouldn't. 

Sabin do provide a value "ccl_nonus_case_country" which gives the alpha 2 iso code, we can use this as a fallback, the reason we are using this as a fallback, is because the jursidiction id array that is sent through contains the subdivisions ids as well as the parent country ids where as "ccl_nonus_case_country" is just one value.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
