### PR TITLE
Map international jurisdictions to international code

### DIFF
--- a/litigation_data_mapper/parsers/family.py
+++ b/litigation_data_mapper/parsers/family.py
@@ -25,6 +25,14 @@ from litigation_data_mapper.parsers.utils import (
 NO_US_STATE_CODE = "XX"  # Default code for federal cases without a state code
 NO_GEOGRAPHY_CODE = "XAA"
 INTERNATIONAL_CODE = "XAB"
+SABIN_INTERNATIONAL_JURISDICTIONS = [
+    "XCT",  # International or Regional Courts and Tribunals
+    "XUN",  # UN Bodies
+    "XAT",  # Arbitral Tribunals
+    "XNC",  # OECD National Contact Points
+    "XEI",  # European Institutions
+    "XXX",  # Other
+]
 
 
 def process_global_case_metadata(
@@ -314,7 +322,10 @@ def get_jurisdiction_iso_codes(
     :return list[str] : A list of ISO codes for the jurisdictions, or a default value if none are found.
     """
 
-    if family.get("acf", {}).get("ccl_nonus_case_country") == "XCT":
+    if (
+        family.get("acf", {}).get("ccl_nonus_case_country")
+        in SABIN_INTERNATIONAL_JURISDICTIONS
+    ):
         return [INTERNATIONAL_CODE]
 
     jurisdiction_ids = family.get("jurisdiction", [])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.5.5"
+version = "1.5.7"
 description = ""
 
 [project.scripts]

--- a/tests/unit_tests/family/test_map_global_family.py
+++ b/tests/unit_tests/family/test_map_global_family.py
@@ -135,6 +135,43 @@ def test_maps_jurisdiction_as_international_iso_code_if_case_jurisdiction_is_XCT
     assert global_family["geographies"] == ["XAB"]
 
 
+@pytest.mark.parametrize(
+    "jurisdiction_code,description",
+    [
+        ("XCT", "International or Regional Courts and Tribunals"),
+        ("XUN", "UN Bodies"),
+        ("XAT", "Arbitral Tribunals"),
+        ("XNC", "OECD National Contact Points"),
+        ("XEI", "European Institutions"),
+        ("XXX", "Other"),
+    ],
+)
+def test_specific_international_jurisdictions_with_descriptions(
+    jurisdiction_code: str,
+    description: str,
+    mock_international_case: dict,
+    mock_context: LitigationContext,
+):
+    mock_international_case["acf"]["ccl_nonus_case_country"] = jurisdiction_code
+    mock_family_data = {
+        "us_cases": [{}],
+        "global_cases": [mock_international_case],
+        "jurisdictions": [{"id": 3, "name": "United Kingdom", "parent": 0}],
+    }
+
+    family_data = map_families(
+        mock_family_data, context=mock_context, concepts={}, collections=[]
+    )
+
+    assert family_data is not None, f"Failed for {description} ({jurisdiction_code})"
+    global_family = family_data[0]
+
+    assert not isinstance(
+        global_family, Failure
+    ), f"Failure for {description} ({jurisdiction_code})"
+    assert global_family["geographies"] == ["XAB"]
+
+
 def test_skips_processing_global_case_data_if_family_contains_missing_data(
     mock_global_case: dict,
 ):


### PR DESCRIPTION
# What's changed?

We have a list of international jurisdictions that can be mapped to our international geography iso code.

<img width="612" height="112" alt="Screenshot 2025-09-24 at 15 28 23" src="https://github.com/user-attachments/assets/44dde2d4-f432-4f94-ad12-f1650570b0f2" />



## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
