### PR TITLE
Sync wordpress to s3 flow

### DIFF
--- a/create_deployment.py
+++ b/create_deployment.py
@@ -4,7 +4,7 @@ from prefect import Flow
 from prefect.blocks.system import JSON
 from prefect.docker.docker_image import DockerImage
 
-from litigation_data_mapper.flows import automatic_updates
+from litigation_data_mapper.flows import automatic_updates, sync_wordpress_to_s3_flow
 
 MEGABYTES_PER_GIGABYTE = 1024
 DEFAULT_FLOW_VARIABLES = {
@@ -13,9 +13,7 @@ DEFAULT_FLOW_VARIABLES = {
 }
 
 
-def create_deployment(
-    flow: Flow,
-) -> None:
+def create_deployment(flow: Flow, cron: str) -> None:
     """Create a deployment for the specified flow"""
     aws_env = os.environ["AWS_ENV"]
     docker_registry = os.environ["DOCKER_REGISTRY"]
@@ -33,7 +31,7 @@ def create_deployment(
             dockerfile="Dockerfile",
         ),
         # this is scheduled to run daily at midnight
-        cron="0 0 * * *",
+        cron=cron,
         work_queue_name=f"mvp-{aws_env}",
         job_variables=job_variables,
         build=False,
@@ -42,4 +40,8 @@ def create_deployment(
 
 
 if __name__ == "__main__":
-    create_deployment(automatic_updates)
+    # at midnight
+    create_deployment(automatic_updates, cron="0 0 * * *")
+    # every 4 hours from 3-23
+    # this means this will have run before the midnight run above
+    create_deployment(sync_wordpress_to_s3_flow, cron="0 3,7,11,15,19,23 * * *")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.5.4"
+version = "1.5.5"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

Moves sync wordpress to s3 to it's own flow, and runs it more regularly.

This is an experiment to see if we can use this data to easily extract deletions and the like on a more regular cadence. 

- [x] Patch
