### PR TITLE
Update work queue name

### DIFF
--- a/create_deployment.py
+++ b/create_deployment.py
@@ -34,7 +34,7 @@ def create_deployment(
         ),
         # this is scheduled to run daily at midnight
         cron="0 0 * * *",
-        work_queue_name=f"mvp-{aws_env}",
+        work_queue_name="default",
         job_variables=job_variables,
         build=False,
         push=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.5.4"
+version = "1.5.5"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- update the work queue name to 'default' to fix the Prefect flow deployment

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
