### PR TITLE
refactor: Use default work queue

### DIFF
--- a/create_deployment.py
+++ b/create_deployment.py
@@ -32,7 +32,6 @@ def create_deployment(flow: Flow, cron: str) -> None:
         ),
         # this is scheduled to run daily at midnight
         cron="0 0 * * *",
-        work_queue_name="default",
         job_variables=job_variables,
         build=False,
         push=False,


### PR DESCRIPTION
# What's changed?

Following on from reducing the number of work queues since we never used the default. Use the default implicitly

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
