### PR TITLE
Do not filter automatic updates by modified_gmt

### DIFF
--- a/litigation_data_mapper/flows.py
+++ b/litigation_data_mapper/flows.py
@@ -41,7 +41,7 @@ def fetch_litigation_data_task() -> LitigationType:
 
 @task
 def trigger_bulk_import(litigation_data: LitigationType) -> requests.models.Response:
-    mapped_data = wrangle_data(litigation_data, debug=True, get_modified_data=True)
+    mapped_data = wrangle_data(litigation_data, debug=True, get_modified_data=False)
     logger.info("✅ Finished mapping litigation data.")
     logger.info("📝 Dumping litigation data to output file")
     output_file = os.path.join(os.getcwd(), "output.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pytest-recording>=0.13.4",
 ]
 name = "litigation-data-mapper"
-version = "1.5.9"
+version = "1.6.0"
 description = ""
 
 [project.scripts]


### PR DESCRIPTION
# What's changed?

- remove filter by modified_gmt from the automatic updates Prefect flow as it is now fast enough to run a full import every night and solves the problem of changes to concepts not being applied

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
