### PR TITLE
fix: hotfix get_deletions

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -779,7 +779,7 @@ wheels = [
 
 [[package]]
 name = "litigation-data-mapper"
-version = "1.5.7"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
We were just dumping out all the IDs - this now does a diff and dumps that out.

Results are being tracked here:
https://linear.app/climate-policy-radar/issue/APP-1288/questions-for-sabin